### PR TITLE
Add sharp-cli for faster image generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,9 @@ jobs:
     - name: 🏗 Setup EAS local builds
       run: yarn global add eas-cli-local-build-plugin
 
+    - name: 🏗 Install Sharp CLI for EAS image generation
+      run: yarn global add sharp-cli
+
     - name: 📦 Install dependencies
       run: yarn
 


### PR DESCRIPTION
Expo Application Services uses `sharp-cli` if it is installed, for faster image generation

### Linked issue

Ref: https://github.com/expo/expo-cli/issues/2676

### Additional context

--
