### PR TITLE
Remove eas-cli-local-build-plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,6 @@ jobs:
         expo-version: latest
         eas-version: latest
 
-    - name: 🏗 Setup EAS local builds
-      run: yarn global add eas-cli-local-build-plugin
-
     - name: 📦 Install dependencies
       run: yarn
 


### PR DESCRIPTION
When I removed it, the `eas build --local ...` command still continued to work

### Linked issue

--

### Additional context

I am actually not sure if maybe this plugin is adding something that I didn't notice - I'm pretty new with these technologies